### PR TITLE
feat: transações atômicas para renovação de contratos

### DIFF
--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -95,6 +95,9 @@ type LeaseRepository interface {
 	Delete(ctx context.Context, id uuid.UUID) error
 	Count(ctx context.Context) (int64, error)
 	CountByStatus(ctx context.Context, status domain.LeaseStatus) (int64, error)
+	// UpdateAndCreateAtomic atualiza um contrato e cria um novo em uma transação atômica
+	// Usado para renovações para garantir consistência de dados
+	UpdateAndCreateAtomic(ctx context.Context, oldLease, newLease *domain.Lease, adjustment *domain.LeaseRentAdjustment) error
 }
 
 // PaymentRepository define as operações de persistência para Payment


### PR DESCRIPTION
## 🎯 Problema Resolvido

Quando a renovação de contrato falhava após marcar o contrato antigo como expirado mas **antes** de criar o novo contrato, o sistema ficava em **estado inconsistente**:

- ❌ Contrato antigo marcado como `expired`
- ❌ **NENHUM** novo contrato criado
- ❌ Unidade e inquilino "presos" sem contrato ativo
- ❌ Impossível renovar novamente (contrato já expirado)
- ❌ Dados corrompidos no banco

**Cenário real que aconteceu:** 
Ao executar o scheduler de renovação automática, a criação do novo contrato falhou pela constraint de `painting_fee_installments`, mas o contrato antigo JÁ havia sido marcado como expirado. Resultado: contrato expirado sem novo contrato.

## ✅ Solução Implementada

### 1. Helper de Transações (`lease_repo.go`)

```go
func (r *LeaseRepo) WithTx(ctx context.Context, fn func(*sqlc.Queries) error) error
```

- Cria transação do banco de dados
- Executa função passada dentro da transação
- **Rollback automático** se houver erro
- **Commit automático** se tudo der certo

### 2. Método Atômico (`UpdateAndCreateAtomic`)

```go
func (r *LeaseRepo) UpdateAndCreateAtomic(
    ctx context.Context, 
    oldLease, newLease *domain.Lease, 
    adjustment *domain.LeaseRentAdjustment
) error
```

Executa em **UMA ÚNICA TRANSAÇÃO**:
1. ✅ Atualiza contrato antigo (marca como `expired`)
2. ✅ Cria novo contrato
3. ✅ Cria registro de reajuste de aluguel (se fornecido)

**Se QUALQUER operação falhar, TODAS são revertidas!**

### 3. Refatoração do `RenewLease`

**Antes (❌ Perigoso):**
```go
if err := s.leaseRepo.Update(ctx, oldLease); err != nil {
    return nil, err
}

if err := s.leaseRepo.Create(ctx, newLease); err != nil {
    // TODO: Rollback do update do oldLease ⚠️
    return nil, err
}

if adjustment != nil {
    s.adjustmentRepo.Create(ctx, adjustment) // Pode falhar também!
}
```

**Depois (✅ Seguro):**
```go
if err := s.leaseRepo.UpdateAndCreateAtomic(ctx, oldLease, newLease, adjustment); err != nil {
    return nil, err // Rollback automático de TUDO
}
```

## 📊 Arquivos Modificados

### Backend
- **internal/repository/interfaces.go** - Adicionado `UpdateAndCreateAtomic` na interface
- **internal/repository/postgres/lease_repo.go** - Implementação da transação
- **internal/service/lease_service.go** - Refatoração do `RenewLease`

### Testes
- **internal/service/lease_service_test.go**
  - Adicionado `UpdateAndCreateAtomic` no `MockLeaseRepo`
  - Atualizado `TestRenewLease_Success`
  - Atualizado `TestRenewLease_WithRentAdjustment`
  - Todos os testes passando ✅

## 🎁 Benefícios

✅ **Consistência de dados 100% garantida**
- Impossível ter contrato expirado sem novo contrato
- Estado sempre consistente no banco

✅ **Atomicidade** 
- Ou TODAS as operações executam OU nenhuma executa
- Não existe "meio termo"

✅ **Rollback automático**
- Sem necessidade de lógica manual de compensação
- Menos código, menos bugs

✅ **Código mais limpo**
- Removido TODO de rollback manual
- Menos tratamento de erro complexo

✅ **Produção segura**
- Evita cenários de dados corrompidos
- Recuperação automática de falhas

## 🧪 Testes

```bash
$ go test ./internal/service/...
PASS
ok  	github.com/lucianoZgabriel/kitnet-manager/internal/service	1.087s
```

- ✅ `TestRenewLease_Success` - Renovação básica
- ✅ `TestRenewLease_WithRentAdjustment` - Renovação com reajuste
- ✅ Todos os outros testes do serviço

## 🔐 Segurança

A transação garante propriedades **ACID**:
- **A**tomicity - Tudo ou nada
- **C**onsistency - Estado sempre válido
- **I**solation - Outras transações não veem estado intermediário
- **D**urability - Commit permanente no banco

## 📝 Notas Técnicas

- Usa `*sql.Tx` do Go standard library
- SQLC suporta transações nativamente via interface `Querier`
- Timeout padrão das queries mantido
- Compatível com PostgreSQL transaction semantics

## 🚀 Próximos Passos

Após merge:
- Deploy automático no Railway
- Testar renovação automática em produção
- Monitorar logs para confirmar funcionamento

---

**Resolves:** Problema de inconsistência de dados em renovações de contrato
**Type:** Bug fix / Enhancement
**Priority:** High (corrige corrupção de dados)